### PR TITLE
User Entity, validation 의존성 gradle 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	// QueryDSL 설정 끝
 
+	// https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 }
 

--- a/src/main/java/com/pickupluck/ecogging/domain/user/entity/LoginType.java
+++ b/src/main/java/com/pickupluck/ecogging/domain/user/entity/LoginType.java
@@ -1,0 +1,5 @@
+package com.pickupluck.ecogging.domain.user.entity;
+
+public enum LoginType {
+    KAKAO
+}

--- a/src/main/java/com/pickupluck/ecogging/domain/user/entity/User.java
+++ b/src/main/java/com/pickupluck/ecogging/domain/user/entity/User.java
@@ -1,13 +1,13 @@
 package com.pickupluck.ecogging.domain.user.entity;
 
-
-import com.pickupluck.ecogging.domain.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
+
+import com.pickupluck.ecogging.domain.BaseEntity;
 
 @Entity
 @Getter

--- a/src/main/java/com/pickupluck/ecogging/domain/user/entity/User.java
+++ b/src/main/java/com/pickupluck/ecogging/domain/user/entity/User.java
@@ -1,0 +1,51 @@
+package com.pickupluck.ecogging.domain.user.entity;
+
+
+import com.pickupluck.ecogging.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @NotNull
+    @Column(unique = true)
+    private String email;
+
+    private String name;
+
+    private String password;
+
+    private String nickname;
+
+    private String tel;
+
+    @Column(name = "noti_yn")
+    private Boolean isNotificationAllowed;
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+
+    @Builder
+    public User(String email, String name, String password, String nickname,
+                String tel, Boolean isNotificationAllowed, LoginType loginType) {
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.nickname = nickname;
+        this.tel = tel;
+        this.isNotificationAllowed = isNotificationAllowed;
+        this.loginType = loginType;
+    }
+}


### PR DESCRIPTION
User Entity, 소셜로그인 위한 enum 타입 LoginType (현재는 카카오만) 추가

Gradle 에 validation 추가했음.
해당 기능으로 Entity 생성 시 어노테이션 기반으로, 컬럼에 여러가지 검사 가능